### PR TITLE
updated ES syntax to fix import issue and for consistency

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,4 @@
 import { Embedded } from "./embedded/index.mjs";
 import { UAPI } from "./uapi/index.mjs";
 
-module.exports = { Embedded, UAPI };
+export { Embedded, UAPI };


### PR DESCRIPTION
Please Review @ViralRuparel @greggmojica 

I was having a lot of trouble importing alloy, it seems to be due to the CJS syntax when ES Module syntax expected. 